### PR TITLE
Bump trestle-auth-otp.gemspec to comply with latest trestle 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@
 /spec/dummy/tmp/*
 
 *.gem
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/trestle-auth-otp.iml
+/.idea/vcs.xml
+/.idea/workspace.xml

--- a/app/views/trestle/admin/_qr_code.html.erb
+++ b/app/views/trestle/admin/_qr_code.html.erb
@@ -1,15 +1,22 @@
-<%- @qr = RQRCode::QRCode.new(@instance.provisioning_uri("#{Trestle.config.site_title} (#{@instance.email})"), size: 10, level: :h) %>
+<!--size: 12 gives more capacity than the default that’s currently capping at 976.-->
+<!--level: :l increases capacity further (lowest error correction, usually fine for on-screen QR).-->
+<%- @qr =
+      RQRCode::QRCode.new(
+        @instance.provisioning_uri("#{Trestle.config.site_title} (#{@instance.email})"),
+        size: 12,
+        level: :l)
+%>
 
 <div class="text-center">
   <p><strong>Scan with Google Authenticator</strong></p>
 
   <%= @qr.as_svg(
-    offset: 0,
-    color: '000',
-    shape_rendering: 'crispEdges',
-    module_size: 4,
-    standalone: true
-  ).html_safe %>
+        offset: 0,
+        color: '000',
+        shape_rendering: 'crispEdges',
+        module_size: 4,
+        standalone: true
+      ).html_safe %>
 
   <small class="my-2">
     <%= @instance.otp_secret_key %>

--- a/app/views/trestle/auth/_otp.html.erb
+++ b/app/views/trestle/auth/_otp.html.erb
@@ -1,6 +1,10 @@
 <div class="form-group">
   <div class="input-group">
-    <span class="input-group-text"><i class="fa fa-lock fa-fw"></i></span>
+    <div class="input-group-prepend">
+      <span class="input-group-text">
+        <i class="fa fa-lock fa-fw"></i>
+      </span>
+    </div>
+    <%= f.text_field :otp_code_token, placeholder: 'Token', class: 'form-control' %>
   </div>
-  <%= f.text_field :otp_code_token, placeholder: 'Token', class: 'form-control' %>
 </div>

--- a/app/views/trestle/auth/_otp.html.erb
+++ b/app/views/trestle/auth/_otp.html.erb
@@ -1,10 +1,6 @@
 <div class="form-group">
   <div class="input-group">
-    <div class="input-group-prepend">
-      <span class="input-group-text">
-        <i class="fa fa-lock fa-fw"></i>
-      </span>
-    </div>
+    <span class="input-group-text"><i class="fa fa-lock fa-fw"></i></span>
     <%= f.text_field :otp_code_token, placeholder: 'Token', class: 'form-control' %>
   </div>
 </div>

--- a/app/views/trestle/auth/_otp.html.erb
+++ b/app/views/trestle/auth/_otp.html.erb
@@ -1,8 +1,6 @@
 <div class="form-group">
   <div class="input-group">
-    <div class="input-group-prepend">
-      <span class="input-group-text"><i class="fa fa-lock fa-fw"></i></span>
-    </div>
-    <%= f.text_field :otp_code_token, placeholder: 'Token', class: 'form-control' %>
+    <span class="input-group-text"><i class="fa fa-lock fa-fw"></i></span>
   </div>
+  <%= f.text_field :otp_code_token, placeholder: 'Token', class: 'form-control' %>
 </div>

--- a/trestle-auth-otp.gemspec
+++ b/trestle-auth-otp.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/McRipper/trestle-auth-otp"
 
-  spec.add_dependency "trestle", "~> 0.9.0"
-  spec.add_dependency "trestle-auth",  "~> 0.4.0"
+  spec.add_dependency "trestle", "~> 0.10"
+  spec.add_dependency "trestle-auth",  "~> 0.5"
   spec.add_dependency "active_model_otp", "~> 2.0"
   spec.add_dependency "rqrcode", "~> 2.0"
 


### PR DESCRIPTION
Updated `trestle` and `trestle-auth` gem versions in the `gemspec` for compatibility with Trestle 0.10. The gem's own version has not been updated.